### PR TITLE
Add missing dependency for Random, clean up duplicate lib in test.hxml

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -8,5 +8,5 @@
     "license": "MIT",    
     "classPath": "src",
     "contributors": ["nightblade9"],
-    "dependencies": { "hxslam": "0.3.1" }
+    "dependencies": { "hxslam": "0.3.1", "polygonal-core": "1.0.4" }
 }

--- a/test.hxml
+++ b/test.hxml
@@ -5,7 +5,6 @@
 -lib hamcrest
 -lib hxslam
 -lib polygonal-core
--lib hxslam
 
 -cp src
 -cp test


### PR DESCRIPTION
340f006 introduced a dependency on `polygonal-core`.

Also noticed that `hxslam` is referenced twice in `test.hxml` and had to clean it up.

Slightly off-topic, but I also am unable to find references to `hamcrest` inside the code, besides the `-lib` references in various .hxml files.  Are there future plans to implement features that depend on `hamcrest` or am I missing something?

Lastly, what's your opinion on dropping the required dependency on `hxslam`? It's required in the haxelib.json file, but is only *truly* required to run the unit test suite.  None of the actual .NET API implementations depend on the short lambda feature.  Technically, an end user could install and run `haxesharp` without installing `hxslam`.  The choice of whether their project should depend on `hxslam` could be left to them entirely.

I can understand why you might require `hxslam` anyway, in that it does add lambdas that are more familiar to .NET developers to Haxe, but from a technical standpoint it doesn't seem necessary for `haxesharp`.