### PR TITLE
Simple regex replace.

### DIFF
--- a/src/haxesharp/text/Regex.hx
+++ b/src/haxesharp/text/Regex.hx
@@ -75,7 +75,27 @@ class Regex
     */
     public function match(input:String):Match
     {                
-        var groups = Regex.matches(input, this.regex, this.options);
+        var groups = Regex.matches(input, this.regex, this.options);        
         return new Match(groups.length > 0, groups);
+    }
+
+    /**
+    Finds all instances where this regex matches the input string, and
+    replaces those with the replacement string. Does not (yet) support
+    groups or named groups.
+    **/
+    public function replace(input:String, replacement:String):String
+    {
+        var output = input;
+        var regex = new EReg(this.regex, this.options);
+
+        while (regex.match(output))
+        {
+            var left = regex.matchedLeft();
+            var right = regex.matchedRight();
+            output = '${left}${right}';
+        }
+
+        return output;
     }
 }

--- a/src/haxesharp/text/Regex.hx
+++ b/src/haxesharp/text/Regex.hx
@@ -93,7 +93,7 @@ class Regex
         {
             var left = regex.matchedLeft();
             var right = regex.matchedRight();
-            output = '${left}${right}';
+            output = '${left}${replacement}${right}';
         }
 
         return output;

--- a/test/haxesharp/text/RegexTest.hx
+++ b/test/haxesharp/text/RegexTest.hx
@@ -68,4 +68,22 @@ class RegexTest
         Assert.that(actual.groups[1], Is.equalTo("231"));
         Assert.that(actual.groups[2], Is.equalTo("right?!"));
     }
+
+    @Test
+    public function replaceReplacesAllInstancesIfMultipleExist()
+    {
+        var input = "44test1 str22i2ng3";
+        var output = new Regex("\\d+", "g").replace(input, "");
+        Assert.that(output, Is.equalTo("test string"));
+        // Didn't butcher the input, did we?
+        Assert.that(input != "test string");
+    }
+
+    @Test
+    public function replaceReturnsInputIfNothingMatches()
+    {
+        var input = "test string";
+        var output = new Regex("\\d+", "g").replace(input, "");
+        Assert.that(output, Is.equalTo(input));
+    }
 }

--- a/test/haxesharp/text/RegexTest.hx
+++ b/test/haxesharp/text/RegexTest.hx
@@ -72,11 +72,11 @@ class RegexTest
     @Test
     public function replaceReplacesAllInstancesIfMultipleExist()
     {
-        var input = "44test1 str22i2ng3";
-        var output = new Regex("\\d+", "g").replace(input, "");
-        Assert.that(output, Is.equalTo("test string"));
+        var input = "vowels exist";
+        var output = new Regex("[aeiou]", "g").replace(input, "+");
+        Assert.that(output, Is.equalTo("v+w+ls +x+st"));
         // Didn't butcher the input, did we?
-        Assert.that(input != "test string");
+        Assert.that(input, Is.equalTo("vowels exist"));
     }
 
     @Test


### PR DESCRIPTION
Code review please @bsinky .

I was initially thinking of extending `Match` to return the start/end position (Haxe provides a `matchedLeft` and `matchedRight` string), but that ended up melting my brain, so I went with a much simpler approach here.

This class is a bit strange because it creates/uses/disposes an `EReg` instance at runtime (doesn't keep it for long-lived operations). Not sure if that will pan out advantageously or not.