### PR TITLE
Implement Linq.single

### DIFF
--- a/src/haxesharp/collections/Linq.hx
+++ b/src/haxesharp/collections/Linq.hx
@@ -3,6 +3,7 @@ package haxesharp.collections;
 using haxesharp.collections.Linq;
 import haxesharp.random.Random;
 import haxesharp.exceptions.InvalidOperationException;
+import haxesharp.exceptions.ArgumentNullException;
 
 /**
  *  LINQ-like extensions for arrays. To use, add: using haxesharp.collections.Linq;
@@ -54,6 +55,60 @@ class Linq<T>
             }
 
             return null;
+        }
+    }
+
+    /**
+    If a predicate is supplied, returns the only element to satisfy the predicate.  Throws an exception if more than one such element exists.
+    If a predicate is not supplied, return the only element in the array.  Throws an exception if the array contains more than one element.
+    In both cases, and exception is thrown if the provided array is null.
+    */
+    public static function single<T>(array:Array<T>, ?predicate:T->Bool):T
+    {
+        if (array == null)
+        {
+            throw new ArgumentNullException('"array" argument cannot be null.');
+        }
+
+        if (predicate == null)
+        {
+            if (array.length == 1)
+            {
+                return array[0];
+            }
+            else if (array.length == 0)
+            {
+                throw new InvalidOperationException('"array" length cannot be 0.');
+            }
+            else
+            {
+                throw new InvalidOperationException('"array" length cannot be greater than 1.');                
+            }
+        }
+        else
+        {
+            var found:T = null;
+            for (a in array)
+            {
+                if (predicate(a))
+                {
+                    if (found == null)
+                    {
+                        found = a;
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException('More than one element satisfies the condition in predicate.');
+                    }
+                }
+            }
+
+            if (found == null)
+            {
+                throw new InvalidOperationException('No element satisfies the condition in predicate.');
+            }
+
+            return found;
         }
     }
 

--- a/test/haxesharp/collections/LinqTest.hx
+++ b/test/haxesharp/collections/LinqTest.hx
@@ -2,6 +2,7 @@ package haxesharp.collections;
 
 using haxesharp.collections.Linq;
 using haxesharp.exceptions.InvalidOperationException;
+using haxesharp.exceptions.ArgumentNullException;
 using haxesharp.test.Assert;
 using haxesharp.text.StringExtensions;
 
@@ -47,6 +48,55 @@ class LinqTest
         var a = ["bell pepper", "tomato", "mushroom"];
         var actual = a.first((f) => f.contains("x"));
         Assert.that(actual, Is.equalTo(null));
+    }
+
+    @Test
+    public function singleThrowsIfArrayIsNull()
+    {
+        Assert.throws(ArgumentNullException, (_) => Linq.single(null));
+        Assert.throws(ArgumentNullException, (_) => Linq.single(null, (x) => true));
+    }
+
+    @Test
+    public function singleWithoutPredicateThrowsIfArrayIsEmpty()
+    {
+        Assert.throws(InvalidOperationException, (_) => [].single());
+    }
+
+    @Test
+    public function singleWithoutPredicateThrowsIfArrayContainsMultipleElements()
+    {
+        Assert.throws(InvalidOperationException, (_) => [1,2,3].single());
+    }
+
+    @Test
+    public function singleWithoutPredicateReturnsTheElementInASingleElementArray()
+    {
+        Assert.that([1].single(), Is.equalTo(1));
+    }
+
+    @Test
+    public function singleWithPredicateThrowsIfArrayIsEmpty()
+    {
+        Assert.throws(InvalidOperationException, (_) => [].single((x) => true));
+    }
+
+    @Test
+    public function singleWithPredicateThrowsIfNoElementSatisfiesPredicate()
+    {
+        Assert.throws(InvalidOperationException, (_) => [1,2,3].single((x) => x == 4));
+    }
+
+    @Test
+    public function singleWithPredicateThrowsIfMultipleElementsSatisfyPredicate()
+    {
+        Assert.throws(InvalidOperationException, (_) => [1,2,3,2].single((x) => x == 2));
+    }
+
+    @Test
+    public function singleWithPredicateReturnsTheElementIfOnlyOneElementSatisfiesPredicate()
+    {
+        Assert.that([1,2,3].single((x) => x == 3), Is.equalTo(3));
     }
 
     @Test


### PR DESCRIPTION
Should satisfy #8, with the exception that `single` as implemented here works like .NET's `System.Linq.Single`, whereas I see that `first` in haxesharp is more like `System.Linq.FirstOrDefault`.

If `System.Linq.SingleOrDefault` is the desired behavior for `single` here, that should be a small matter of removing some exceptions and the related unit tests.

Documentation for this can be generated just prior to this PR being merged, or even after, if need be.